### PR TITLE
CI: Don't install Package Control

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           package-name: Package Control
           sublime-text-version: ${{ matrix.st-version }}
+          install-package-control: false
       - uses: SublimeText/UnitTesting/actions/run-tests@v1
         with:
           package-name: Package Control


### PR DESCRIPTION
This commit ensures CI tests use checked out "Package Control" revision, by not also installing official release.